### PR TITLE
Link to raw github image from AppData XML

### DIFF
--- a/helpers/appdata/kdocker.appdata.xml
+++ b/helpers/appdata/kdocker.appdata.xml
@@ -14,7 +14,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-        <image width="640" height="360">https://github.com/user-none/KDocker/blob/master/helpers/context.png</image>
+        <image width="640" height="360">https://raw.githubusercontent.com/user-none/KDocker/master/helpers/appdata/context.png</image>
         <caption>Context menu showing available actions and option settings</caption>
     </screenshot>
     <screenshot></screenshot>


### PR DESCRIPTION
... because the image link advice on their help page only works for github wiki,
otherwise you see the full github page:
https://github.com/user-none/KDocker/blob/master/helpers/appdata/context.png
instead of just the image:
https://raw.githubusercontent.com/user-none/KDocker/master/helpers/appdata/context.png
