### PR TITLE
Fix for extraneous events generated by KDE 5.14

### DIFF
--- a/src/trayitem.h
+++ b/src/trayitem.h
@@ -148,6 +148,7 @@ private:
     QIcon createIcon(Window window);
 
     bool isBadWindow();
+    bool isOnCurrentDesktop();
 
     bool m_iconified;
     bool m_is_restoring;


### PR DESCRIPTION
Fixes Issue #43. KDE/Plasma 5.14 started generating XCB_UNMAP_NOTIFY and XCB_PROPERTY_NOTIFY events when the window leaves the current desktop (i.e. the user changes the current desktop) and these need to be ignored.
This has also been tested on KDE/Plasma 5.12 and works as expected.