### PR TITLE
Added attention icon that is shown if iconified app needs attention.

### DIFF
--- a/helpers/kdocker.pod
+++ b/helpers/kdocker.pod
@@ -49,6 +49,11 @@ B<kdocker> [I<options>]I<>
 
  Custom icon path
 
+=item B<-I> I<file>
+
+ Custom attention icon path. This icon is set if the title
+ of the application window changes while it is iconified.
+
 =item B<-j>
 
  Case sensitive name (title) matching

--- a/src/constants.cpp
+++ b/src/constants.cpp
@@ -26,6 +26,6 @@ const QString Constants::DOM_NAME    = "kdocker.com";
 const QString Constants::WEBSITE     = "https://github.com/user-none/KDocker";
 const QString Constants::APP_VERSION = "5.2";
 
-const char *Constants::OPTIONSTRING = "+abd:e:fhi:jklmn:op:qrstvuw:x:";
+const char *Constants::OPTIONSTRING = "+abd:e:fhi:I:jklmn:op:qrstvuw:x:";
 
 const QString Constants::ABOUT_MESSAGE = QString("%1 %2\n\n%3").arg(Constants::APP_NAME).arg(Constants::APP_VERSION).arg(Constants::WEBSITE);

--- a/src/kdocker.cpp
+++ b/src/kdocker.cpp
@@ -194,6 +194,7 @@ void KDocker::printHelp() {
     commands.append(qMakePair(QString("-f"),      tr("Dock window that has focus (active window)")));
     commands.append(qMakePair(QString("-h"),      tr("Display this help")));
     commands.append(qMakePair(QString("-i file"), tr("Set the tray icon to file")));
+    commands.append(qMakePair(QString("-I file"), tr("Set the attention tray icon to file. This icon is set if the title of the application window changes while it is iconified.")));
     commands.append(qMakePair(QString("-j"),      tr("Case senstive name (title) matching")));
     commands.append(qMakePair(QString("-k"),      tr("Regex minimal matching")));
     commands.append(qMakePair(QString("-l"),      tr("Iconify when focus lost")));

--- a/src/trayitem.h
+++ b/src/trayitem.h
@@ -41,6 +41,7 @@
 #endif
 
 #define DEFAULT_CustomIcon        QString()
+#define DEFAULT_AttentionIcon     QString()
 #define DEFAULT_BalloonTimeout    4000       // 4 seconds
 #define DEFAULT_SkipTaskbar       false
 #define DEFAULT_SkipPager         false
@@ -67,6 +68,7 @@ enum Option
 
 struct TrayItemArgs {   // from cmd line only
     QString sCustomIcon;
+    QString sAttentionIcon;
     int iBalloonTimeout;
     int8_t opt[Option_MAX];
 };
@@ -75,6 +77,7 @@ typedef TrayItemArgs TrayItemConfig;
 
 struct TrayItemSettings {  // from 1) cmd line, 2) app config, 3) global config, 4) default
     QString sCustomIcon;
+    QString sAttentionIcon;
     int iBalloonTimeout;
     bool opt[Option_MAX];
 };
@@ -102,7 +105,9 @@ public:
 public slots:
     void closeWindow();
     void setCustomIcon(QString path);
+    void setAttentionIcon(QString path);
     void selectCustomIcon(bool value);
+    void selectAttentionIcon(bool value);
     void setSkipTaskbar(bool value);
     void setSkipPager(bool value);
     void setSticky(bool value);
@@ -154,13 +159,18 @@ private:
 
     void createContextMenu();
     QIcon createIcon(Window window);
+    QString selectIcon(QString title);
 
     bool isBadWindow();
     bool isOnCurrentDesktop();
 
+    bool m_wantsAttention;
     bool m_iconified;
     bool m_is_restoring;
     bool m_customIcon;
+
+    QIcon m_defaultIcon;
+    QIcon m_attentionIcon;
 
     QSettings m_config;
     TrayItemSettings m_settings;
@@ -175,6 +185,7 @@ private:
     QMenu *m_contextMenu;
     QMenu *m_optionsMenu;
     QAction *m_actionSetIcon;
+    QAction *m_actionSetAttentionIcon;
     QAction *m_actionSkipTaskbar;
     QAction *m_actionSkipPager;
     QAction *m_actionSticky;

--- a/src/trayitemmanager.cpp
+++ b/src/trayitemmanager.cpp
@@ -213,6 +213,9 @@ void TrayItemManager::processCommand(const QStringList &args) {
             case 'i':
                 settings.sCustomIcon = QString::fromLocal8Bit(optarg);
                 break;
+            case 'I':
+                settings.sAttentionIcon = QString::fromLocal8Bit(optarg);
+                break;
             case 'j':
                 windowName.setCaseSensitivity(Qt::CaseSensitive);
                 break;


### PR DESCRIPTION
Some applications change their title to indicate that there is something that requires the user's attention. For example, a chat app might change the title to "Chat app [n]" if there are n unread messages. Showing a notification for every title change is not always desired, because it might be too distracting or even annoying.

For that reason, this commit adds an optional "attention icon". It can be set via command line argument or in the context menu. If the icon is set and the app changes its title while being iconified, the "attention icon" is set. As soon as the app is restored, the normal icon is set again. Thus, this mechanism is much less pushy, but still tells the user that there is something to look at (just once until the user restores the app).