### PR TITLE
Avoid deadlock during shut down on UNIX signals

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -18,19 +18,40 @@
  */
 
 #include "application.h"
+#include <sys/socket.h>
+#include <unistd.h>
 
+int Application::m_closeSignalFd[2];
 
 Application::Application(const QString &appId, int &argc, char **argv) : QtSingleApplication(appId, argc, argv) {
     m_kdocker = 0;
+
+    // Translate UNIX signals to Qt signals (See https://doc.qt.io/qt-5/unix-signals.html)
+    if (::socketpair(AF_UNIX, SOCK_STREAM, 0, m_closeSignalFd))
+       qFatal("Couldn't create signal handling socketpair");
+
+    m_closeSignalSocketNotifier = new QSocketNotifier(m_closeSignalFd[1], QSocketNotifier::Read, this);
+    connect(m_closeSignalSocketNotifier, SIGNAL(activated(QSocketDescriptor)), this, SLOT(handleCloseSignal()));
 }
 
 void Application::setKDockerInstance(KDocker *kdocker) {
     m_kdocker = kdocker;
 }
 
-void Application::close() {
+void Application::notifyCloseSignal() {
+    char tmp = 1;
+    ::write(m_closeSignalFd[0], &tmp, sizeof(tmp));
+}
+
+void Application::handleCloseSignal() {
+    m_closeSignalSocketNotifier->setEnabled(false);
+    char tmp;
+    ::read(m_closeSignalFd[1], &tmp, sizeof(tmp));
+
     if (m_kdocker) {
         m_kdocker->undockAll();
     }
     quit();
+
+    m_closeSignalSocketNotifier->setEnabled(true);
 }

--- a/src/application.h
+++ b/src/application.h
@@ -21,6 +21,7 @@
 #define	_APPLICATION_H
 
 #include <QtSingleApplication>
+#include <QSocketNotifier>
 
 #include "kdocker.h"
 
@@ -32,10 +33,16 @@ public:
     Application(const QString &appId, int &argc, char **argv);
 
     void setKDockerInstance(KDocker *kdocker);
-    void close();
+    void notifyCloseSignal();
+
+public slots:
+    void handleCloseSignal();
 
 private:
     KDocker *m_kdocker;
+
+    static int m_closeSignalFd[2];
+    QSocketNotifier *m_closeSignalSocketNotifier;
 };
 
 #endif	/* _APPLICATION_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,7 @@
 static void sighandler(int sig) {
     Q_UNUSED(sig);
 
-    dynamic_cast<Application*> (qApp)->close();
+    dynamic_cast<Application*> (qApp)->notifyCloseSignal();
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
(New attempt to fix the problem after PR #98 failed.)

Qt functions should not be called during shut down caused by a UNIX signal. Instead, we should generate a Qt signal during the UNIX signal, and process it there, as explained on Qt's docs.: https://doc.qt.io/qt-5/unix-signals.html

This prevents a potential deadlock while the user session is destroyed, where we first receive a `SIGTERM` and starting shutting down, we try to undock the application, but since X11 is shutting down, calls to X11 functions fail and generates a `SIGHUP`, which initiates another shut down and causes a deadlock. Or sometimes, KDocker just gets stuck forever waiting inside an X11 function.

Fixes: #67