### PR TITLE
Change path for bash-completion file

### DIFF
--- a/kdocker.pro
+++ b/kdocker.pro
@@ -43,7 +43,7 @@ desktop.files = helpers/kdocker.desktop
 appdata.path = /usr/share/appdata
 appdata.files = helpers/appdata/kdocker.appdata.xml
 
-completion.path = /etc/bash_completion.d
+completion.path = /usr/share/bash-completion/completions
 completion.files = helpers/kdocker
 
 target.path = /usr/bin


### PR DESCRIPTION
The current path is deprecated, and is only available for compatibility
reasons.
If you have `pkg-config`installed you can get the old path with
`pkg-config --variable=compatdir bash-completion`
and the new path
`pkg-config --variable=completionsdir bash-completion`

This information can also be found in the 'bash-completion' repo
https://github.com/scop/bash-completion/blob/master/README.md#faq