### PR TITLE
Appstream

### DIFF
--- a/helpers/appdata/kdocker.appdata.xml
+++ b/helpers/appdata/kdocker.appdata.xml
@@ -20,7 +20,6 @@
         <image width="640" height="360">https://raw.githubusercontent.com/user-none/KDocker/master/helpers/appdata/context.png</image>
         <caption>Context menu showing available actions and option settings</caption>
     </screenshot>
-    <screenshot></screenshot>
   </screenshots>
   <url type="homepage">https://github.com/user-none/KDocker</url>
   <url type="bugtracker">https://github.com/user-none/KDocker/issues</url>

--- a/kdocker.pro
+++ b/kdocker.pro
@@ -40,7 +40,7 @@ icons.files = resources/images/kdocker.png
 desktop.path = /usr/share/applications
 desktop.files = helpers/kdocker.desktop
 
-appdata.path = /usr/share/appdata
+appdata.path = /usr/share/metainfo
 appdata.files = helpers/appdata/kdocker.appdata.xml
 
 completion.path = /etc/bash_completion.d


### PR DESCRIPTION
The path `/usr/share/appdata` has been deprecated for quite some time.
It's mentioned in appstream `NEWS` file as far back as 2018, version
0.12.1.
In the official documentation it's mentioned that RHEL 7 and Ubuntu 16.04
LTS supports the metainfo path.
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#spec-component-location

The empty screenshot tag generates an error, so we're removing it.